### PR TITLE
add requirement wheel to satisfy missing dependencie for playsound package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel
 opencv-python
 mediapipe
 tk


### PR DESCRIPTION
add requirement wheel to satisfy missing dependencie for playsound package on install in venv as in https://stackoverflow.com/questions/76142067/on-github-actions-pip-install-playsound-failed-with-the-oserror-could-not-g